### PR TITLE
Venue Cards Landing Page - Skeleton Loaders (Placeholder)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite + React + TS</title>
+</head>
+
+<body>
+  <div id="root" class="flex flex-col justify-center items-center"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/src/Components/layout.tsx
+++ b/src/Components/layout.tsx
@@ -2,13 +2,13 @@ import { Outlet } from 'react-router-dom';
 
 export const Layout = () => {
   return (
-    <div>
+    <>
       <header></header>
-      <main>
+      <main className='w-full'>
         {' '}
         <Outlet />
       </main>
       <footer></footer>
-    </div>
+    </>
   );
 };

--- a/src/Components/loading/loadingVenueCard.tsx
+++ b/src/Components/loading/loadingVenueCard.tsx
@@ -1,0 +1,13 @@
+export default function LoadingVenueCard () {
+  return (
+    <article className="flex flex-col max-w-[245px] gap-[20px] animate-pulse">
+      <div className="imagePlaceHolder  h-[200px] bg-[#C4C4C4] rounded-xl"></div>
+      <div className="title&RatingWrapper flex justify-between">
+        <div className="titlePlaceHolder bg-[#C4C4C4] h-[27px] w-[60%]"></div>
+        <div className="ratingPlaceHolder bg-[#C4C4C4] h-[27px] w-[35%]"></div>
+      </div>
+      <div className="descPlaceHolder  bg-[#C4C4C4] w-full h-[50px]"></div>
+      <div className="pricePlaceHolder  bg-[#C4C4C4] w-[35%] h-[27px]"></div>
+    </article>
+  )
+}

--- a/src/Components/loading/loadingVenueCard.tsx
+++ b/src/Components/loading/loadingVenueCard.tsx
@@ -1,6 +1,6 @@
 export default function LoadingVenueCard () {
   return (
-    <article className="flex flex-col max-w-[245px] gap-[20px] animate-pulse">
+    <article className="flex flex-col w-[90%] md:max-w-[245px] gap-[20px] animate-pulse">
       <div className="imagePlaceHolder  h-[200px] bg-[#C4C4C4] rounded-xl"></div>
       <div className="title&RatingWrapper flex justify-between">
         <div className="titlePlaceHolder bg-[#C4C4C4] h-[27px] w-[60%]"></div>

--- a/src/Components/loading/test.tsx
+++ b/src/Components/loading/test.tsx
@@ -1,3 +1,0 @@
-export const test = () => {
-  return <div>Test</div>;
-};

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -3,7 +3,7 @@ import LoadingVenueCard from "../Components/loading/loadingVenueCard";
 
 export const HomePage = () => {
   return (
-    <div>
+    <div className="flex flex-col items-center">
       <h1>Home Page</h1>
       <h2>Test commit hook </h2>
       <LoadingVenueCard />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,8 +1,13 @@
+import LoadingVenueCard from "../Components/loading/loadingVenueCard";
+
+
 export const HomePage = () => {
   return (
     <div>
       <h1>Home Page</h1>
       <h2>Test commit hook </h2>
+      <LoadingVenueCard />
+
       <h2>Test terminal log when commit</h2>
     </div>
   );


### PR DESCRIPTION
### What’s installed:
- Created placeholder component for venue cards that pulsate until api data finishes fetching and we replace the placeholder with actual data

### How to test:
- Launch branch and/or loading-components branch in `npm run dev` and see that the loader is popping up. 

Closes #11 