### PR TITLE
fix: add react lazy load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,20 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Layout } from './Components/AppLayout';
-import { HomePage } from './pages/home';
-import { VenuePage } from './pages/venue';
-import { ProfilePage } from './pages/profile';
-import { EditPage } from './pages/edit';
-import { CreatePage } from './pages/create';
 import './index.css';
 import './fonts.css';
 import { DataProvider } from './context/common';
 import { AnimatePresence } from 'framer-motion';
+
+import { lazy, Suspense } from 'react';
+import SkeletonLoaderVenue from './Components/loading/SkeletonLoaderVenue';
+import SkeletonLoaderHome from './Components/loading/SkeletonLoaderHome';
+import SkeletonLoaderProfile from './Components/loading/SkeletonLoaderProfile';
+
+const HomePage = lazy(() => import('./pages/home'));
+const VenuePage = lazy(() => import('./pages/venue'));
+const ProfilePage = lazy(() => import('./pages/profile'));
+const EditPage = lazy(() => import('./pages/edit'));
+const CreatePage = lazy(() => import('./pages/create'));
 
 const AppRoutes = () => {
   const location = useLocation();
@@ -17,11 +23,46 @@ const AppRoutes = () => {
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<Layout />}>
-          <Route index element={<HomePage />} />
-          <Route path="/venues" element={<VenuePage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/edit" element={<EditPage />} />
-          <Route path="/create" element={<CreatePage />} />
+          <Route
+            index
+            element={
+              <Suspense fallback={<SkeletonLoaderHome />}>
+                <HomePage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/venues"
+            element={
+              <Suspense fallback={<SkeletonLoaderVenue />}>
+                <VenuePage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <Suspense fallback={<SkeletonLoaderProfile />}>
+                <ProfilePage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/edit"
+            element={
+              <Suspense fallback={null}>
+                <EditPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/create"
+            element={
+              <Suspense fallback={null}>
+                <CreatePage />
+              </Suspense>
+            }
+          />
         </Route>
       </Routes>
     </AnimatePresence>

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -12,7 +12,8 @@ import { fadeOutOnlyVariants } from '../Constants/constants';
  *
  * @returns {JSX.Element} The rendered page where users can create a new venue.
  */
-export const CreatePage = () => {
+
+const CreatePage = () => {
   useEffect(() => {
     document.title = 'HAL - New Venue';
   }, []);
@@ -32,3 +33,5 @@ export const CreatePage = () => {
     </motion.div>
   );
 };
+
+export default CreatePage;

--- a/src/pages/edit.tsx
+++ b/src/pages/edit.tsx
@@ -33,7 +33,7 @@ import { runVenueValidations } from '../utilities/validation/runVenueValidations
  * @returns {JSX.Element} The rendered form for editing the venue.
  */
 
-export const EditPage = () => {
+const EditPage = () => {
   useEffect(() => {
     document.title = 'Edit Venue';
   }, []);
@@ -352,3 +352,5 @@ export const EditPage = () => {
     </motion.div>
   );
 };
+
+export default EditPage;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -21,7 +21,7 @@ import { fadeOutOnlyVariants } from '../Constants/constants';
  * @returns {JSX.Element} The rendered homepage with a list of venues and a search bar.
  */
 
-export const HomePage = () => {
+const HomePage = () => {
   const [venues, setVenues] = useState<Venue[]>([]);
   const [allVenues, setAllVenues] = useState<Venue[]>([]);
   const [loading, setLoading] = useState(true);
@@ -73,3 +73,5 @@ export const HomePage = () => {
     </motion.div>
   );
 };
+
+export default HomePage;

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -23,7 +23,7 @@ function useQuery() {
  * @returns {JSX.Element} The rendered profile page with the user's profile information or an error message.
  */
 
-export const ProfilePage = () => {
+const ProfilePage = () => {
   const query = useQuery();
   const username = query.get('username');
 
@@ -60,3 +60,5 @@ export const ProfilePage = () => {
     </motion.div>
   );
 };
+
+export default ProfilePage;

--- a/src/pages/venue.tsx
+++ b/src/pages/venue.tsx
@@ -35,7 +35,7 @@ import { fadeOutOnlyVariants } from '../Constants/constants';
  * and the venue's bookings (if the user is the owner).
  */
 
-export const VenuePage = () => {
+const VenuePage = () => {
   const [searchParams] = useSearchParams();
   const id = searchParams.get('id') ?? ``;
   const [venue, setVenue] = useState<Venue>();
@@ -271,3 +271,5 @@ export const AmenityItem = ({ value }: AmenityItemProps) => {
     </div>
   );
 };
+
+export default VenuePage;


### PR DESCRIPTION
## Added React lazy load 


- Using React.lazy() to code-split route-based pages (Home, Profile, Venue, etc.)
- Wrapping lazy components in Suspense with existing skeleton loaders as fallback
- Keeping Edit and Create pages eagerly loaded (since they're form-based and lightweight)

This helps reduce initial bundle size and improves perceived load time for users.