### PR TITLE
201 fix venue page

### DIFF
--- a/src/Components/StarRating.tsx
+++ b/src/Components/StarRating.tsx
@@ -54,15 +54,18 @@ export const StarRating: React.FC<StarRatingProps> = ({ rating }) => {
 
       {/* Half Star (simulated) */}
       {hasHalfStar && (
-        <div className="relative w-[18px] md:w-[25px] h-auto">
+        <div className="relative">
           <Star
             key="half"
-            className="absolute top-0 left-0"
+            className="absolute top-0 left-0 w-[18px] md:w-[25px] h-auto"
             fill="currentColor"
             stroke="currentColor"
             style={{ clipPath: 'inset(0 50% 0 0)' }} // Half-filled
           />
-          <Star className="absolute top-0 left-0" stroke="currentColor" />
+          <Star
+            className="absolute top-0 left-0 w-[18px] md:w-[25px] h-auto"
+            stroke="currentColor"
+          />
         </div>
       )}
 

--- a/src/Components/loading/SkeletonLoaderVenue.tsx
+++ b/src/Components/loading/SkeletonLoaderVenue.tsx
@@ -13,7 +13,7 @@
 
 export default function SkeletonLoaderVenue() {
   return (
-    <div className="font-primary w-full h-full px-5 flex flex-wrap lg:flex-nowrap justify-center  lg:justify-between gap-5 max-w-[1440px] animate-pulse">
+    <div className="font-primary w-full h-full px-5 flex flex-wrap lg:flex-nowrap justify-center  lg:justify-between gap-5 max-w-[1440px] animate-pulse pt-5 lg:mt-10">
       {/* Left column */}
       <div className="max-w-[700px] w-full mb-5 md:mb-10 flex flex-col gap-10">
         {/* Gallery placeholder */}

--- a/src/pages/venue.tsx
+++ b/src/pages/venue.tsx
@@ -77,7 +77,7 @@ const VenuePage = () => {
       animate="animate"
       exit="exit"
     >
-      <div className="font-primary w-full h-full  flex flex-wrap lg:flex-nowrap justify-center md:justify-evenly lg:justify-between gap-5">
+      <div className="font-primary w-full h-full  flex flex-wrap lg:flex-nowrap justify-center md:justify-evenly lg:justify-between gap-5 pt-5 lg:mt-10">
         <div className="max-w-[700px] w-full mb-5 md:mb-10">
           {venue.media && venue.media.length > 0 ? (
             <GalleryComponent media={venue.media} />
@@ -118,7 +118,7 @@ const VenuePage = () => {
             </div>
           </div>
         </div>
-        <div className="flex flex-col gap-2 w-full md:max-w-[700px] md:min-w-[350px] px-2">
+        <div className="flex flex-col gap-2 w-full md:max-w-[700px] md:min-w-[350px] lg:px-2">
           <div className="flex justify-between items-center flex-wrap gap-10">
             <h1 className="headlineOne">{venue.name}</h1>
 

--- a/src/pages/venue.tsx
+++ b/src/pages/venue.tsx
@@ -130,14 +130,14 @@ const VenuePage = () => {
                 className="flex gap-2 items-center scale-95 hover:scale-100 transition"
                 onClick={() => localStorage.setItem('editVenue', JSON.stringify(venue))}
               >
-                <span>Edit Venue</span>
+                <span>Edit</span>
                 <Pencil className="h-4" />
               </Link>
               <button
                 onClick={() => handleDeleteClick()}
                 className="flex gap-2 items-center cursor-pointer scale-95 hover:scale-100 transition"
               >
-                <span>Delete Venue</span> <Trash2 className="h-4" />
+                <span>Delete</span> <Trash2 className="h-4" />
               </button>
             </div>
           </div>


### PR DESCRIPTION
### Venue page fixes

- Added some space between header and main content
- Added same space for skeleton loader
- Updated to lg:px-2 for larger screenad and no px on lower screens for the text info box
- Fixed half filled stars to same size as filled stars
- Changed Edit Venue and Delete Venue to Edit and Delete